### PR TITLE
Search wildcard fix (based on jsword-stepbible-2022 branch)

### DIFF
--- a/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndex.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndex.java
@@ -338,8 +338,11 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
                 QueryParser parser = new QueryParser(Version.LUCENE_29, LuceneIndex.FIELD_BODY, analyzer);
                 parser.setAllowLeadingWildcard(true);
                 String analyzedSearch = search;
-                if((search.trim().charAt(0)) > 256)
+
+                // if this is a wild card search, the Analyzer was not applied
+                if(((search.trim().charAt(0)) > 256) && ((search.trim().charAt(search.length() -1 )) == '*' ))
                     analyzedSearch = analyze(LuceneIndex.FIELD_BODY, search, analyzer);
+
                 Query query = parser.parse(analyzedSearch);
                 //log.info("ParsedQuery- {}", query.toString());
 

--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewCharTokenizer.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewCharTokenizer.java
@@ -1,0 +1,23 @@
+package org.crosswire.jsword.index.lucene.analysis;
+
+import org.apache.lucene.analysis.LetterTokenizer;
+
+import java.io.Reader;
+
+public class HebrewCharTokenizer  extends LetterTokenizer {
+
+    public HebrewCharTokenizer(Reader in) {
+        super(in);
+    }
+
+    @Override
+    protected boolean isTokenChar(char c) {
+        return (c >= 0x590 && c <= 0x5ff );
+    }
+
+    @Override
+    protected char normalize(char c) {
+        return Character.toLowerCase(c);
+    }
+}
+

--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewLuceneAnalyzer.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewLuceneAnalyzer.java
@@ -44,7 +44,7 @@ public class HebrewLuceneAnalyzer extends AbstractBookAnalyzer {
 
     @Override
     public TokenStream tokenStream(String fieldName, Reader reader) {
-        TokenStream result = new StandardTokenizer(matchVersion, reader);
+        TokenStream result = new HebrewCharTokenizer(reader);
         result = new HebrewPointingFilter(result);
 
         return result;
@@ -55,7 +55,7 @@ public class HebrewLuceneAnalyzer extends AbstractBookAnalyzer {
     public TokenStream reusableTokenStream(String fieldName, Reader reader) throws IOException {
         SavedStreams streams = (SavedStreams) getPreviousTokenStream();
         if (streams == null) {
-            streams = new SavedStreams(new StandardTokenizer(matchVersion, reader));
+            streams = new SavedStreams(new HebrewCharTokenizer(reader));
             streams.setResult(new HebrewPointingFilter(streams.getResult()));
 
             setPreviousTokenStream(streams);

--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewPointingFilter.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewPointingFilter.java
@@ -22,7 +22,7 @@ public class HebrewPointingFilter extends AbstractBookTokenFilter {
     @Override
     public boolean incrementToken() throws IOException {
         if (this.input.incrementToken()) {
-            final String unaccentedForm = unPoint(this.termAtt.term(), false);
+            final String unaccentedForm = unPoint(this.termAtt.term(), true);
             this.termAtt.setTermBuffer(unaccentedForm);
             return true;
         } else {


### PR DESCRIPTION
I re-created a pull request.  Instead of a base of the crosswire:master, I changed the base to STEPBible/jsword:jsword-stepbible-2022.  